### PR TITLE
Add mood tracking and visual growth charts

### DIFF
--- a/lib/features/growth/growth_panel.dart
+++ b/lib/features/growth/growth_panel.dart
@@ -1,27 +1,68 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'visual/growth_tree_widget.dart';
 import 'visual/heatmap_mood_widget.dart';
 import 'visual/milestone_chart_widget.dart';
 import 'visual/memory_timeline_widget.dart';
+import 'growth_provider.dart';
+import 'growth_repository.dart';
+import '../otak_kecil/otak_kecil_provider.dart';
+import '../../core/ai/ai_service.dart';
 
 class GrowthPanel extends StatelessWidget {
   const GrowthPanel({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Growth Panel')),
-      body: ListView(
-        children: const [
-          GrowthTreeWidget(),
-          Divider(),
-          HeatmapMoodWidget(),
-          Divider(),
-          MilestoneChartWidget(),
-          Divider(),
-          MemoryTimelineWidget(),
-        ],
+    return ChangeNotifierProxyProvider<OtakKecilProvider, GrowthProvider>(
+      create: (_) => GrowthProvider(repository: GrowthRepository()),
+      update: (_, mem, growth) {
+        growth ??= GrowthProvider(repository: GrowthRepository());
+        growth.loadData(mem.memories);
+        return growth;
+      },
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Growth Panel')),
+        body: ListView(
+          children: const [
+            GrowthTreeWidget(),
+            Divider(),
+            HeatmapMoodWidget(),
+            Divider(),
+            MilestoneChartWidget(),
+            Divider(),
+            MemoryTimelineWidget(),
+            Divider(),
+            _AiNextStep(),
+          ],
+        ),
       ),
+    );
+  }
+}
+
+class _AiNextStep extends StatelessWidget {
+  const _AiNextStep();
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<GrowthProvider>(context);
+    final prompt =
+        'Berikan saran langkah selanjutnya berdasarkan data growth pengguna.';
+    return FutureBuilder<String>(
+      future: AiService().getInsight(prompt),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(snapshot.data!),
+        );
+      },
     );
   }
 }

--- a/lib/features/growth/growth_provider.dart
+++ b/lib/features/growth/growth_provider.dart
@@ -1,10 +1,28 @@
 import 'package:flutter/material.dart';
+import '../otak_kecil/memory_entry.dart';
+import 'growth_repository.dart';
+import 'growth_model.dart';
 
 class GrowthProvider with ChangeNotifier {
-  final List<String> progresses = [];
+  final GrowthRepository repository;
+  final List<GrowthModel> progresses = [];
+  Map<DateTime, double> moodStats = {};
+  Map<DateTime, int> progressStats = {};
+
+  GrowthProvider({required this.repository});
 
   void addProgress(String prog) {
-    progresses.insert(0, prog);
+    progresses.insert(0, GrowthModel(prog, DateTime.now()));
+    repository.add(prog);
+    notifyListeners();
+  }
+
+  void loadData(List<MemoryEntry> memories) {
+    progresses
+      ..clear()
+      ..addAll(repository.fetchAll());
+    moodStats = repository.aggregateMood(memories);
+    progressStats = repository.aggregateProgress();
     notifyListeners();
   }
 }

--- a/lib/features/growth/growth_repository.dart
+++ b/lib/features/growth/growth_repository.dart
@@ -1,9 +1,37 @@
+import '../otak_kecil/memory_entry.dart';
+import 'growth_model.dart';
+
 class GrowthRepository {
-  final List<String> _cache = [];
+  final List<GrowthModel> _cache = [];
 
-  List<String> fetchAll() => List.from(_cache);
+  List<GrowthModel> fetchAll() => List.from(_cache);
 
-  void add(String prog) => _cache.insert(0, prog);
+  void add(String prog) =>
+      _cache.insert(0, GrowthModel(prog, DateTime.now()));
+
+  Map<DateTime, double> aggregateMood(List<MemoryEntry> memories) {
+    final Map<DateTime, List<int>> daily = {};
+    for (final m in memories) {
+      if (m.moodScore != null) {
+        final day = DateTime(m.timestamp.year, m.timestamp.month, m.timestamp.day);
+        daily.putIfAbsent(day, () => []);
+        daily[day]!.add(m.moodScore!);
+      }
+    }
+    return daily.map((day, scores) {
+      final avg = scores.reduce((a, b) => a + b) / scores.length;
+      return MapEntry(day, avg);
+    });
+  }
+
+  Map<DateTime, int> aggregateProgress() {
+    final Map<DateTime, int> monthly = {};
+    for (final g in _cache) {
+      final key = DateTime(g.createdAt.year, g.createdAt.month);
+      monthly.update(key, (v) => v + 1, ifAbsent: () => 1);
+    }
+    return monthly;
+  }
 
   void clear() => _cache.clear();
 }

--- a/lib/features/growth/growth_widget.dart
+++ b/lib/features/growth/growth_widget.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'growth_provider.dart';
 import 'growth_form.dart';
+import 'growth_repository.dart';
+import 'growth_model.dart';
 
 class GrowthWidget extends StatelessWidget {
   const GrowthWidget({super.key});
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => GrowthProvider(),
+      create: (_) => GrowthProvider(repository: GrowthRepository()),
       child: const _GrowthView(),
     );
   }
@@ -28,17 +30,21 @@ class _GrowthView extends StatelessWidget {
         const Text("Riwayat Perkembangan:", style: TextStyle(fontWeight: FontWeight.bold)),
         Expanded(
           child: provider.progresses.isEmpty
-            ? const Center(child: Text("Belum ada progres."))
-            : ListView.builder(
-                itemCount: provider.progresses.length,
-                itemBuilder: (ctx, i) => Card(
-                  margin: const EdgeInsets.symmetric(vertical: 4),
-                  child: ListTile(
-                    leading: const Icon(Icons.check_circle_outline),
-                    title: Text(provider.progresses[i]),
-                  ),
+              ? const Center(child: Text("Belum ada progres."))
+              : ListView.builder(
+                  itemCount: provider.progresses.length,
+                  itemBuilder: (ctx, i) {
+                    final g = provider.progresses[i];
+                    return Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4),
+                      child: ListTile(
+                        leading: const Icon(Icons.check_circle_outline),
+                        title: Text(g.progress),
+                        subtitle: Text(g.createdAt.toIso8601String()),
+                      ),
+                    );
+                  },
                 ),
-              ),
         ),
       ],
     );

--- a/lib/features/growth/visual/heatmap_mood_widget.dart
+++ b/lib/features/growth/visual/heatmap_mood_widget.dart
@@ -1,20 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../growth_provider.dart';
 
 class HeatmapMoodWidget extends StatelessWidget {
   const HeatmapMoodWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final stats = context.watch<GrowthProvider>().moodStats;
+
+    Color colorForScore(double v) {
+      if (v >= 4) return Colors.green;
+      if (v >= 3) return Colors.lightGreen;
+      if (v >= 2) return Colors.orange;
+      return Colors.red;
+    }
+
     return Card(
       margin: const EdgeInsets.all(16),
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
-          children: const [
-            Icon(Icons.heat_pump, size: 48, color: Colors.orange),
-            SizedBox(height: 8),
-            Text("Heatmap Mood"),
-            Text("Feature: Kalender emosi, warna sesuai suasana harian"),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Heatmap Mood', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            if (stats.isEmpty)
+              const Text('Belum ada data mood')
+            else
+              Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                children: [
+                  for (final entry in stats.entries)
+                    Container(
+                      width: 16,
+                      height: 16,
+                      color: colorForScore(entry.value),
+                    )
+                ],
+              ),
           ],
         ),
       ),

--- a/lib/features/growth/visual/memory_timeline_widget.dart
+++ b/lib/features/growth/visual/memory_timeline_widget.dart
@@ -1,20 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../otak_kecil/otak_kecil_provider.dart';
 
 class MemoryTimelineWidget extends StatelessWidget {
   const MemoryTimelineWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final memories = context.watch<OtakKecilProvider>().memories;
     return Card(
       margin: const EdgeInsets.all(16),
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
-          children: const [
-            Icon(Icons.timeline, size: 48, color: Colors.blueGrey),
-            SizedBox(height: 8),
-            Text("Memory Timeline"),
-            Text("Feature: Narasi perjalanan hidup, flashback progres"),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Memory Timeline', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            if (memories.isEmpty)
+              const Text('Belum ada memori')
+            else
+              Column(
+                children: [
+                  for (final m in memories.take(5))
+                    ListTile(
+                      leading: const Icon(Icons.timeline),
+                      title: Text(m.content),
+                      subtitle: Text(m.timestamp.toIso8601String()),
+                    ),
+                ],
+              ),
           ],
         ),
       ),

--- a/lib/features/growth/visual/milestone_chart_widget.dart
+++ b/lib/features/growth/visual/milestone_chart_widget.dart
@@ -1,20 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../growth_provider.dart';
 
 class MilestoneChartWidget extends StatelessWidget {
   const MilestoneChartWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final stats = context.watch<GrowthProvider>().progressStats;
     return Card(
       margin: const EdgeInsets.all(16),
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
-          children: const [
-            Icon(Icons.emoji_events, size: 48, color: Colors.amber),
-            SizedBox(height: 8),
-            Text("Milestone Chart"),
-            Text("Feature: Daftar pencapaian, progres bulanan/tahunan"),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Milestone Chart', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            if (stats.isEmpty)
+              const Text('Belum ada progres')
+            else
+              Row(
+                children: [
+                  for (final entry in stats.entries)
+                    Expanded(
+                      child: Container(
+                        margin: const EdgeInsets.symmetric(horizontal: 2),
+                        height: (entry.value * 10).toDouble(),
+                        color: Colors.blueAccent,
+                      ),
+                    ),
+                ],
+              ),
           ],
         ),
       ),

--- a/lib/features/otak_kecil/memory_entry.dart
+++ b/lib/features/otak_kecil/memory_entry.dart
@@ -6,6 +6,8 @@ class MemoryEntry {
   final List<String> tags;
   final Map<String, dynamic> context;
   final Map<String, dynamic>? aiGenerated;
+  final int? moodScore; // e.g. 1-5
+  final List<String>? activities;
 
   MemoryEntry({
     required this.id,
@@ -15,5 +17,7 @@ class MemoryEntry {
     required this.tags,
     required this.context,
     this.aiGenerated,
+    this.moodScore,
+    this.activities,
   });
 }

--- a/lib/features/otak_kecil/otak_kecil_provider.dart
+++ b/lib/features/otak_kecil/otak_kecil_provider.dart
@@ -13,4 +13,19 @@ class OtakKecilProvider with ChangeNotifier {
     memories.clear();
     notifyListeners();
   }
+
+  List<MemoryEntry> filterByDate(DateTime start, DateTime end) {
+    return memories
+        .where((m) => !m.timestamp.isBefore(start) && !m.timestamp.isAfter(end))
+        .toList();
+  }
+
+  List<MemoryEntry> filterByMood(int min, int max) {
+    return memories
+        .where((m) =>
+            m.moodScore != null &&
+            m.moodScore! >= min &&
+            m.moodScore! <= max)
+        .toList();
+  }
 }

--- a/lib/features/otak_kecil/otak_kecil_widget.dart
+++ b/lib/features/otak_kecil/otak_kecil_widget.dart
@@ -36,6 +36,7 @@ class _OtakKecilView extends StatelessWidget {
                 content: "Contoh memori pada \${now.toIso8601String()}",
                 tags: const ["contoh"],
                 context: const {},
+                moodScore: 3,
               ),
             );
           },
@@ -54,7 +55,8 @@ class _OtakKecilView extends StatelessWidget {
                     child: ListTile(
                       leading: const Icon(Icons.memory),
                       title: Text(m.content),
-                      subtitle: Text("Waktu: \${m.timestamp} | Tag: \${m.tags.join(', ')}"),
+                      subtitle: Text(
+                          "Waktu: \${m.timestamp} | Mood: \${m.moodScore ?? '-'} | Tag: \${m.tags.join(', ')}"),
                     ),
                   );
                 },


### PR DESCRIPTION
## Summary
- extend `MemoryEntry` with `moodScore` and `activities`
- provide filtering by date and mood in `OtakKecilProvider`
- aggregate mood and progress stats in `GrowthRepository` and `GrowthProvider`
- show simple charts in the growth visuals and AI insight recommendation

## Testing
- `dart` and `flutter` were unavailable so formatting or runtime tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6863e067fac48324b3171adde024fac7