### PR TITLE
Add quick-add FAB to main pages

### DIFF
--- a/lib/core/common/quick_add_dialog.dart
+++ b/lib/core/common/quick_add_dialog.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+Future<void> showQuickAddDialog(
+  BuildContext context,
+  void Function(String) onSubmit, {
+  String? hint,
+}) {
+  final controller = TextEditingController();
+
+  void submit() {
+    final text = controller.text.trim();
+    if (text.isEmpty) return;
+    onSubmit(text);
+    Navigator.of(context).pop();
+  }
+
+  return showDialog(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        decoration: InputDecoration(hintText: hint),
+        onSubmitted: (_) => submit(),
+      ),
+      actions: [
+        TextButton(onPressed: submit, child: const Text('Add')),
+      ],
+    ),
+  );
+}

--- a/lib/features/beranda/beranda_page.dart
+++ b/lib/features/beranda/beranda_page.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/common/quick_add_dialog.dart';
 import 'beranda_widget.dart';
+import 'beranda_provider.dart';
 
 class BerandaPage extends StatelessWidget {
   const BerandaPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => BerandaProvider(),
+      child: const _BerandaView(),
+    );
+  }
+}
+
+class _BerandaView extends StatelessWidget {
+  const _BerandaView();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -10,6 +26,14 @@ class BerandaPage extends StatelessWidget {
       body: const Padding(
         padding: EdgeInsets.all(16),
         child: BerandaWidget(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => showQuickAddDialog(
+          context,
+          context.read<BerandaProvider>().addNote,
+          hint: 'Tambah catatan...',
+        ),
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -1,21 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'beranda_provider.dart';
 import 'beranda_form.dart';
-import 'package:provider/provider.dart';
 
 class BerandaWidget extends StatelessWidget {
   const BerandaWidget({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => BerandaProvider(),
-      child: const _BerandaView(),
-    );
-  }
-}
-
-class _BerandaView extends StatelessWidget {
-  const _BerandaView();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/chat/chat_page.dart
+++ b/lib/features/chat/chat_page.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/common/quick_add_dialog.dart';
 import 'chat_widget.dart';
+import 'chat_provider.dart';
 
 class ChatPage extends StatelessWidget {
   const ChatPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => ChatProvider(),
+      child: const _ChatView(),
+    );
+  }
+}
+
+class _ChatView extends StatelessWidget {
+  const _ChatView();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -10,6 +26,14 @@ class ChatPage extends StatelessWidget {
       body: const Padding(
         padding: EdgeInsets.all(16),
         child: ChatWidget(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => showQuickAddDialog(
+          context,
+          context.read<ChatProvider>().addMessage,
+          hint: 'Ketik pesan...',
+        ),
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/features/chat/chat_widget.dart
+++ b/lib/features/chat/chat_widget.dart
@@ -5,17 +5,6 @@ import 'chat_form.dart';
 
 class ChatWidget extends StatelessWidget {
   const ChatWidget({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => ChatProvider(),
-      child: const _ChatView(),
-    );
-  }
-}
-
-class _ChatView extends StatelessWidget {
-  const _ChatView();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/growth/growth_page.dart
+++ b/lib/features/growth/growth_page.dart
@@ -1,8 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/common/quick_add_dialog.dart';
 import 'growth_widget.dart';
+import 'growth_provider.dart';
+import 'growth_repository.dart';
 
 class GrowthPage extends StatelessWidget {
   const GrowthPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => GrowthProvider(repository: GrowthRepository()),
+      child: const _GrowthView(),
+    );
+  }
+}
+
+class _GrowthView extends StatelessWidget {
+  const _GrowthView();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -10,6 +27,14 @@ class GrowthPage extends StatelessWidget {
       body: const Padding(
         padding: EdgeInsets.all(16),
         child: GrowthWidget(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => showQuickAddDialog(
+          context,
+          context.read<GrowthProvider>().addProgress,
+          hint: 'Catat perkembangan...',
+        ),
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/features/growth/growth_widget.dart
+++ b/lib/features/growth/growth_widget.dart
@@ -7,17 +7,6 @@ import 'growth_model.dart';
 
 class GrowthWidget extends StatelessWidget {
   const GrowthWidget({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => GrowthProvider(repository: GrowthRepository()),
-      child: const _GrowthView(),
-    );
-  }
-}
-
-class _GrowthView extends StatelessWidget {
-  const _GrowthView();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/psy/psy_page.dart
+++ b/lib/features/psy/psy_page.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/common/quick_add_dialog.dart';
 import 'psy_widget.dart';
+import 'psy_provider.dart';
 
 class PsyPage extends StatelessWidget {
   const PsyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => PsyProvider(),
+      child: const _PsyView(),
+    );
+  }
+}
+
+class _PsyView extends StatelessWidget {
+  const _PsyView();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -10,6 +26,14 @@ class PsyPage extends StatelessWidget {
       body: const Padding(
         padding: EdgeInsets.all(16),
         child: PsyWidget(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => showQuickAddDialog(
+          context,
+          context.read<PsyProvider>().addPsy,
+          hint: 'Catatan psikologi...',
+        ),
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/features/psy/psy_widget.dart
+++ b/lib/features/psy/psy_widget.dart
@@ -7,17 +7,6 @@ import 'consultation/consultation_widget.dart';
 
 class PsyWidget extends StatelessWidget {
   const PsyWidget({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => PsyProvider(),
-      child: const _PsyView(),
-    );
-  }
-}
-
-class _PsyView extends StatelessWidget {
-  const _PsyView();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- add reusable `showQuickAddDialog` helper
- wrap main pages with providers
- hook up FAB on each page to open quick dialog
- move providers out of feature widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e24aeda48324bee8f0b6e22cbe91