### PR TITLE
Integrate OtakKecil into home

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ See `docs/folder_structure.md`.
 ## Features
 
 - Modular, scalable, and extensible
-- Memory Engine ("Otak Kecil")
+- Memory Engine ("Otak Kecil") integrated with Beranda
 - Growth, Chat, Psy modules

--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../otak_kecil/otak_kecil_page.dart';
 import 'beranda_provider.dart';
 import 'beranda_form.dart';
 
@@ -27,7 +28,17 @@ class BerandaWidget extends StatelessWidget {
                     title: Text(provider.notes[i]),
                   ),
                 ),
-              ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        ElevatedButton.icon(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const OtakKecilPage()),
+            );
+          },
+          icon: const Icon(Icons.memory),
+          label: const Text('Buka Otak Kecil'),
         ),
       ],
     );

--- a/lib/features/otak_kecil/otak_kecil_widget.dart
+++ b/lib/features/otak_kecil/otak_kecil_widget.dart
@@ -7,10 +7,7 @@ class OtakKecilWidget extends StatelessWidget {
   const OtakKecilWidget({super.key});
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => OtakKecilProvider(),
-      child: const _OtakKecilView(),
-    );
+    return const _OtakKecilView();
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,8 @@ import 'features/beranda/beranda_page.dart';
 import 'features/chat/chat_page.dart';
 import 'features/growth/growth_page.dart';
 import 'features/psy/psy_page.dart';
-import 'features/otak_kecil/otak_kecil_page.dart';
+import 'features/otak_kecil/otak_kecil_provider.dart';
+import 'package:provider/provider.dart';
 import 'core/common/app_theme.dart';
 
 void main() {
@@ -15,10 +16,13 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Otak Kecil App',
-      theme: AppTheme.light,
-      home: const MainNav(),
+    return ChangeNotifierProvider(
+      create: (_) => OtakKecilProvider(),
+      child: MaterialApp(
+        title: 'Otak Kecil App',
+        theme: AppTheme.light,
+        home: const MainNav(),
+      ),
     );
   }
 }
@@ -36,7 +40,6 @@ class _MainNavState extends State<MainNav> {
     ChatPage(),
     GrowthPage(),
     PsyPage(),
-    OtakKecilPage(),
   ];
 
   @override
@@ -51,7 +54,6 @@ class _MainNavState extends State<MainNav> {
           BottomNavigationBarItem(icon: Icon(Icons.chat), label: "Chat"),
           BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: "Growth"),
           BottomNavigationBarItem(icon: Icon(Icons.psychology), label: "Psy"),
-          BottomNavigationBarItem(icon: Icon(Icons.memory), label: "Otak Kecil"),
         ],
       ),
     );

--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -3,7 +3,6 @@ import 'features/beranda/beranda_widget.dart';
 import 'features/chat/chat_widget.dart';
 import 'features/growth/growth_widget.dart';
 import 'features/psy/psy_widget.dart';
-import 'features/otak_kecil/otak_kecil_widget.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({super.key});
@@ -18,7 +17,6 @@ class _MainPageState extends State<MainPage> {
     ChatWidget(),
     GrowthWidget(),
     PsyWidget(),
-    OtakKecilWidget(),
   ];
   @override
   Widget build(BuildContext context) {
@@ -32,7 +30,6 @@ class _MainPageState extends State<MainPage> {
           BottomNavigationBarItem(icon: Icon(Icons.chat), label: 'Chat'),
           BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: 'Growth'),
           BottomNavigationBarItem(icon: Icon(Icons.psychology), label: 'Psy'),
-          BottomNavigationBarItem(icon: Icon(Icons.memory), label: 'Otak Kecil'),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- integrate OtakKecil provider at the root app level
- remove OtakKecil tab from the main navigation
- expose OtakKecil page from Beranda
- update README feature list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e37e70448324ab3de8b44f97be75