### PR TITLE
Add adaptive greeting banner

### DIFF
--- a/lib/core/ai/ai_service.dart
+++ b/lib/core/ai/ai_service.dart
@@ -1,8 +1,15 @@
 // Wrapper service AI (bisa untuk API OpenRouter, Local ML, dsb)
 class AiService {
+  // Simpel cache untuk mencegah pemanggilan berulang dengan prompt yang sama
+  static final Map<String, String> _cache = {};
+
   // Contoh stub: dapatkan rekomendasi atau hasil AI
   Future<String> getInsight(String prompt) async {
+    if (_cache.containsKey(prompt)) return _cache[prompt]!;
+
     // TODO: Implementasi panggil AI
-    return "Hasil AI untuk prompt: $prompt";
+    final result = "Hasil AI untuk prompt: $prompt";
+    _cache[prompt] = result;
+    return result;
   }
 }

--- a/lib/core/common/adaptive_greeting_banner.dart
+++ b/lib/core/common/adaptive_greeting_banner.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import '../../features/chat/greeting/greeting_service.dart';
+import '../ai/ai_service.dart';
+
+class AdaptiveGreetingBanner extends StatefulWidget {
+  final String pageName;
+  const AdaptiveGreetingBanner({super.key, required this.pageName});
+
+  @override
+  State<AdaptiveGreetingBanner> createState() => _AdaptiveGreetingBannerState();
+}
+
+class _AdaptiveGreetingBannerState extends State<AdaptiveGreetingBanner> {
+  late Future<String> _futureInsight;
+
+  @override
+  void initState() {
+    super.initState();
+    final greeting = GreetingService.getGreeting();
+    final prompt =
+        '$greeting Saya sedang di tab ${widget.pageName}. Berikan refleksi singkat.';
+    _futureInsight = AiService().getInsight(prompt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final greeting = GreetingService.getGreeting();
+    return FutureBuilder<String>(
+      future: _futureInsight,
+      builder: (context, snapshot) {
+        final aiText = snapshot.data;
+        return Card(
+          margin: const EdgeInsets.only(bottom: 16),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(greeting, style: const TextStyle(fontSize: 18)),
+                const SizedBox(height: 8),
+                if (snapshot.connectionState == ConnectionState.waiting)
+                  const LinearProgressIndicator()
+                else if (aiText != null)
+                  Text(aiText)
+                else
+                  const SizedBox.shrink(),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/beranda/beranda_page.dart
+++ b/lib/features/beranda/beranda_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../core/common/quick_add_dialog.dart';
+import '../../core/common/adaptive_greeting_banner.dart';
 import 'beranda_widget.dart';
 import 'beranda_provider.dart';
 
@@ -23,9 +24,14 @@ class _BerandaView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Beranda')),
-      body: const Padding(
-        padding: EdgeInsets.all(16),
-        child: BerandaWidget(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: const [
+            AdaptiveGreetingBanner(pageName: 'Beranda'),
+            Expanded(child: BerandaWidget()),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => showQuickAddDialog(

--- a/lib/features/chat/chat_page.dart
+++ b/lib/features/chat/chat_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../core/common/quick_add_dialog.dart';
+import '../../core/common/adaptive_greeting_banner.dart';
 import 'chat_widget.dart';
 import 'chat_provider.dart';
 
@@ -23,9 +24,14 @@ class _ChatView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Chat')),
-      body: const Padding(
-        padding: EdgeInsets.all(16),
-        child: ChatWidget(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: const [
+            AdaptiveGreetingBanner(pageName: 'Chat'),
+            Expanded(child: ChatWidget()),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => showQuickAddDialog(

--- a/lib/features/growth/growth_page.dart
+++ b/lib/features/growth/growth_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../core/common/quick_add_dialog.dart';
+import '../../core/common/adaptive_greeting_banner.dart';
 import 'growth_widget.dart';
 import 'growth_provider.dart';
 import 'growth_repository.dart';
@@ -24,9 +25,14 @@ class _GrowthView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Growth')),
-      body: const Padding(
-        padding: EdgeInsets.all(16),
-        child: GrowthWidget(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: const [
+            AdaptiveGreetingBanner(pageName: 'Growth'),
+            Expanded(child: GrowthWidget()),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => showQuickAddDialog(

--- a/lib/features/psy/psy_page.dart
+++ b/lib/features/psy/psy_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../core/common/quick_add_dialog.dart';
+import '../../core/common/adaptive_greeting_banner.dart';
 import 'psy_widget.dart';
 import 'psy_provider.dart';
 
@@ -23,9 +24,14 @@ class _PsyView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Psy')),
-      body: const Padding(
-        padding: EdgeInsets.all(16),
-        child: PsyWidget(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: const [
+            AdaptiveGreetingBanner(pageName: 'Psy'),
+            Expanded(child: PsyWidget()),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => showQuickAddDialog(


### PR DESCRIPTION
## Summary
- create `AdaptiveGreetingBanner` that mixes greeting service with AI insight
- cache AI calls in `AiService`
- show the banner on Beranda, Chat, Growth, and Psy pages

## Testing
- `dart format lib/core/common/adaptive_greeting_banner.dart lib/core/ai/ai_service.dart lib/features/beranda/beranda_page.dart lib/features/chat/chat_page.dart lib/features/growth/growth_page.dart lib/features/psy/psy_page.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e526fec883249e55fde0087cad62