### PR TITLE
Add pastel theme and animated list transitions

### DIFF
--- a/lib/core/common/app_theme.dart
+++ b/lib/core/common/app_theme.dart
@@ -1,14 +1,28 @@
 import 'package:flutter/material.dart';
 
 class AppTheme {
+  static const _pastelBlue = Color(0xFFB3E5FC);
+  static const _pastelIndigo = Color(0xFF9FA8DA);
+  static const _lightBackground = Color(0xFFFFFDF7);
+  static const _darkBackground = Color(0xFF303034);
+
   static ThemeData get light => ThemeData(
-        primarySwatch: Colors.blue,
-        scaffoldBackgroundColor: Colors.white,
-        brightness: Brightness.light,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: _pastelBlue,
+          brightness: Brightness.light,
+        ),
+        scaffoldBackgroundColor: _lightBackground,
+        visualDensity: const VisualDensity(horizontal: 2, vertical: 2),
+        useMaterial3: true,
       );
+
   static ThemeData get dark => ThemeData(
-        primarySwatch: Colors.indigo,
-        scaffoldBackgroundColor: Colors.black,
-        brightness: Brightness.dark,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: _pastelIndigo,
+          brightness: Brightness.dark,
+        ),
+        scaffoldBackgroundColor: _darkBackground,
+        visualDensity: const VisualDensity(horizontal: 2, vertical: 2),
+        useMaterial3: true,
       );
 }

--- a/lib/core/common/pastel_empty_state.dart
+++ b/lib/core/common/pastel_empty_state.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class PastelEmptyState extends StatelessWidget {
+  final String message;
+  final IconData icon;
+  const PastelEmptyState({super.key, required this.message, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.all(32),
+        decoration: BoxDecoration(
+          color: Colors.blue[50],
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: Colors.blue[200]),
+            const SizedBox(height: 12),
+            Text(message, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../otak_kecil/otak_kecil_page.dart';
 import 'beranda_provider.dart';
 import 'beranda_form.dart';
+import '../../core/common/pastel_empty_state.dart';
 
 class BerandaWidget extends StatelessWidget {
   const BerandaWidget({super.key});
@@ -17,17 +18,24 @@ class BerandaWidget extends StatelessWidget {
         const SizedBox(height: 12),
         const Text("Catatan Beranda:", style: TextStyle(fontWeight: FontWeight.bold)),
         Expanded(
-          child: provider.notes.isEmpty
-            ? const Center(child: Text("Belum ada catatan."))
-            : ListView.builder(
-                itemCount: provider.notes.length,
-                itemBuilder: (ctx, i) => Card(
-                  margin: const EdgeInsets.symmetric(vertical: 4),
-                  child: ListTile(
-                    leading: const Icon(Icons.note),
-                    title: Text(provider.notes[i]),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            child: provider.notes.isEmpty
+                ? const PastelEmptyState(
+                    message: "Belum ada catatan.",
+                    icon: Icons.note_add,
+                  )
+                : ListView.builder(
+                    key: ValueKey(provider.notes.length),
+                    itemCount: provider.notes.length,
+                    itemBuilder: (ctx, i) => Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4),
+                      child: ListTile(
+                        leading: const Icon(Icons.note),
+                        title: Text(provider.notes[i]),
+                      ),
+                    ),
                   ),
-                ),
           ),
         ),
         const SizedBox(height: 12),

--- a/lib/features/chat/chat_widget.dart
+++ b/lib/features/chat/chat_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'chat_provider.dart';
 import 'chat_form.dart';
+import '../../core/common/pastel_empty_state.dart';
 
 class ChatWidget extends StatelessWidget {
   const ChatWidget({super.key});
@@ -12,26 +13,34 @@ class ChatWidget extends StatelessWidget {
     return Column(
       children: [
         Expanded(
-          child: provider.messages.isEmpty
-            ? const Center(child: Text("Belum ada pesan."))
-            : ListView.builder(
-                reverse: true,
-                itemCount: provider.messages.length,
-                itemBuilder: (ctx, i) => Align(
-                  alignment: i % 2 == 0
-                      ? Alignment.centerRight
-                      : Alignment.centerLeft,
-                  child: Container(
-                    margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
-                    padding: const EdgeInsets.all(10),
-                    decoration: BoxDecoration(
-                      color: i % 2 == 0 ? Colors.blue[100] : Colors.grey[200],
-                      borderRadius: BorderRadius.circular(12),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            child: provider.messages.isEmpty
+                ? const PastelEmptyState(
+                    message: "Belum ada pesan.",
+                    icon: Icons.chat_bubble_outline,
+                  )
+                : ListView.builder(
+                    key: ValueKey(provider.messages.length),
+                    reverse: true,
+                    itemCount: provider.messages.length,
+                    itemBuilder: (ctx, i) => Align(
+                      alignment:
+                          i % 2 == 0 ? Alignment.centerRight : Alignment.centerLeft,
+                      child: Container(
+                        margin: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 12),
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color:
+                              i % 2 == 0 ? Colors.blue[100] : Colors.grey[200],
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(provider.messages[i]),
+                      ),
                     ),
-                    child: Text(provider.messages[i]),
                   ),
-                ),
-              ),
+          ),
         ),
         ChatForm(onSubmit: provider.addMessage),
       ],

--- a/lib/features/growth/growth_widget.dart
+++ b/lib/features/growth/growth_widget.dart
@@ -4,6 +4,7 @@ import 'growth_provider.dart';
 import 'growth_form.dart';
 import 'growth_repository.dart';
 import 'growth_model.dart';
+import '../../core/common/pastel_empty_state.dart';
 
 class GrowthWidget extends StatelessWidget {
   const GrowthWidget({super.key});
@@ -18,22 +19,29 @@ class GrowthWidget extends StatelessWidget {
         const SizedBox(height: 12),
         const Text("Riwayat Perkembangan:", style: TextStyle(fontWeight: FontWeight.bold)),
         Expanded(
-          child: provider.progresses.isEmpty
-              ? const Center(child: Text("Belum ada progres."))
-              : ListView.builder(
-                  itemCount: provider.progresses.length,
-                  itemBuilder: (ctx, i) {
-                    final g = provider.progresses[i];
-                    return Card(
-                      margin: const EdgeInsets.symmetric(vertical: 4),
-                      child: ListTile(
-                        leading: const Icon(Icons.check_circle_outline),
-                        title: Text(g.progress),
-                        subtitle: Text(g.createdAt.toIso8601String()),
-                      ),
-                    );
-                  },
-                ),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            child: provider.progresses.isEmpty
+                ? const PastelEmptyState(
+                    message: "Belum ada progres.",
+                    icon: Icons.check_circle_outline,
+                  )
+                : ListView.builder(
+                    key: ValueKey(provider.progresses.length),
+                    itemCount: provider.progresses.length,
+                    itemBuilder: (ctx, i) {
+                      final g = provider.progresses[i];
+                      return Card(
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        child: ListTile(
+                          leading: const Icon(Icons.check_circle_outline),
+                          title: Text(g.progress),
+                          subtitle: Text(g.createdAt.toIso8601String()),
+                        ),
+                      );
+                    },
+                  ),
+          ),
         ),
       ],
     );

--- a/lib/features/otak_kecil/otak_kecil_widget.dart
+++ b/lib/features/otak_kecil/otak_kecil_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'otak_kecil_provider.dart';
 import 'memory_entry.dart';
+import '../../core/common/pastel_empty_state.dart';
 
 class OtakKecilWidget extends StatelessWidget {
   const OtakKecilWidget({super.key});
@@ -41,23 +42,30 @@ class _OtakKecilView extends StatelessWidget {
         const SizedBox(height: 16),
         const Text("Memori Tersimpan:", style: TextStyle(fontWeight: FontWeight.bold)),
         Expanded(
-          child: provider.memories.isEmpty
-            ? const Center(child: Text("Belum ada memori."))
-            : ListView.builder(
-                itemCount: provider.memories.length,
-                itemBuilder: (ctx, i) {
-                  final m = provider.memories[i];
-                  return Card(
-                    margin: const EdgeInsets.symmetric(vertical: 4),
-                    child: ListTile(
-                      leading: const Icon(Icons.memory),
-                      title: Text(m.content),
-                      subtitle: Text(
-                          "Waktu: \${m.timestamp} | Mood: \${m.moodScore ?? '-'} | Tag: \${m.tags.join(', ')}"),
-                    ),
-                  );
-                },
-              ),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            child: provider.memories.isEmpty
+                ? const PastelEmptyState(
+                    message: "Belum ada memori.",
+                    icon: Icons.memory,
+                  )
+                : ListView.builder(
+                    key: ValueKey(provider.memories.length),
+                    itemCount: provider.memories.length,
+                    itemBuilder: (ctx, i) {
+                      final m = provider.memories[i];
+                      return Card(
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        child: ListTile(
+                          leading: const Icon(Icons.memory),
+                          title: Text(m.content),
+                          subtitle: Text(
+                              "Waktu: \${m.timestamp} | Mood: \${m.moodScore ?? '-'} | Tag: \${m.tags.join(', ')}"),
+                        ),
+                      );
+                    },
+                  ),
+          ),
         ),
       ],
     );

--- a/lib/features/psy/psy_widget.dart
+++ b/lib/features/psy/psy_widget.dart
@@ -4,6 +4,7 @@ import 'psy_provider.dart';
 import 'psy_form.dart';
 import 'tests/psychology_test_list_widget.dart';
 import 'consultation/consultation_widget.dart';
+import '../../core/common/pastel_empty_state.dart';
 
 class PsyWidget extends StatelessWidget {
   const PsyWidget({super.key});
@@ -11,6 +12,25 @@ class PsyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final provider = Provider.of<PsyProvider>(context);
+    final notesWidget = provider.psyNotes.isEmpty
+        ? const PastelEmptyState(
+            message: "Belum ada catatan psikis.",
+            icon: Icons.psychology,
+          )
+        : Column(
+            key: ValueKey(provider.psyNotes.length),
+            children: provider.psyNotes
+                .map((note) => Card(
+                      margin: const EdgeInsets.symmetric(
+                          vertical: 4, horizontal: 10),
+                      child: ListTile(
+                        leading: const Icon(Icons.psychology),
+                        title: Text(note),
+                      ),
+                    ))
+                .toList(),
+          );
+
     return ListView(
       children: [
         PsyForm(onSubmit: provider.addPsy),
@@ -20,18 +40,10 @@ class PsyWidget extends StatelessWidget {
         const ConsultationWidget(),
         const SizedBox(height: 18),
         const Text("Catatan Psikologi:", style: TextStyle(fontWeight: FontWeight.bold)),
-        ...provider.psyNotes.isEmpty
-          ? [const Padding(
-              padding: EdgeInsets.only(top: 18),
-              child: Center(child: Text("Belum ada catatan psikis.")),
-            )]
-          : provider.psyNotes.map((note) => Card(
-              margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 10),
-              child: ListTile(
-                leading: const Icon(Icons.psychology),
-                title: Text(note),
-              ),
-            )),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: notesWidget,
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- design new PastelEmptyState widget for calm empty list placeholders
- switch app theme to pastel colors with extra whitespace
- animate list updates in main widgets using `AnimatedSwitcher`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e6269af483249fa809b58ac91c4e