### PR TITLE
Add AI insight and goal saving

### DIFF
--- a/lib/features/growth/growth_widget.dart
+++ b/lib/features/growth/growth_widget.dart
@@ -1,21 +1,53 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'growth_provider.dart';
-import 'growth_form.dart';
-import 'growth_repository.dart';
-import 'growth_model.dart';
-import '../../core/common/pastel_empty_state.dart';
 
-class GrowthWidget extends StatelessWidget {
+import '../../core/ai/ai_service.dart';
+import '../../core/common/pastel_empty_state.dart';
+import 'growth_form.dart';
+import 'growth_provider.dart';
+
+class GrowthWidget extends StatefulWidget {
   const GrowthWidget({super.key});
+
+  @override
+  State<GrowthWidget> createState() => _GrowthWidgetState();
+}
+
+class _GrowthWidgetState extends State<GrowthWidget> {
+  late Future<String>? _futureInsight;
+  int _lastCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureInsight = null;
+  }
+
+  void _refreshInsight(GrowthProvider provider) {
+    if (provider.progresses.isEmpty) return;
+    if (_futureInsight != null && provider.progresses.length == _lastCount) {
+      return;
+    }
+    final latest = provider.progresses.first.progress;
+    final prompt =
+        'Saya telah mencapai "$latest". Apa langkah perkembangan selanjutnya?';
+    setState(() {
+      _futureInsight = AiService().getInsight(prompt);
+      _lastCount = provider.progresses.length;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final provider = Provider.of<GrowthProvider>(context);
+    _refreshInsight(provider);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        GrowthForm(onSubmit: provider.addProgress),
+        GrowthForm(onSubmit: (p) {
+          provider.addProgress(p);
+          _refreshInsight(provider);
+        }),
         const SizedBox(height: 12),
         const Text("Riwayat Perkembangan:", style: TextStyle(fontWeight: FontWeight.bold)),
         Expanded(
@@ -43,7 +75,57 @@ class GrowthWidget extends StatelessWidget {
                   ),
           ),
         ),
+        if (_futureInsight != null)
+          _NextStepCard(
+            future: _futureInsight!,
+            onSave: provider.addProgress,
+          ),
       ],
+    );
+  }
+}
+
+class _NextStepCard extends StatelessWidget {
+  final Future<String> future;
+  final void Function(String) onSave;
+  const _NextStepCard({required this.future, required this.onSave});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String>(
+      future: future,
+      builder: (context, snap) {
+        if (!snap.hasData) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final text = snap.data!;
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 12),
+          color: Colors.green[50],
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Next Step',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                Text(text),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: () => onSave(text),
+                    child: const Text('Save as Goal'),
+                  ),
+                )
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- call `AiService.getInsight` after showing growth and psychology test results
- display a "Next Step" card with AI insight and "Save as Goal" action

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e72f59848324840c2e3b88d365b9