### PR TITLE
Implement minimal FastAPI backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,44 @@
+# Backend API
+
+This backend provides a very small FastAPI application that exposes a few in-memory endpoints. It can be used by the mobile app to store and retrieve simple data during development.
+
+## Running locally
+
+Install dependencies and run the server:
+
+```bash
+pip install fastapi uvicorn
+uvicorn app.main:app --reload
+```
+
+The API will be available at `http://localhost:8000`.
+
+## Example requests
+
+Add a memory:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/memory \
+  -H "Content-Type: application/json" \
+  -d '{"content": "My first memory"}'
+```
+
+Get all memories:
+
+```bash
+curl http://localhost:8000/api/v1/memory
+```
+
+Add a growth progress entry:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/growth \
+  -H "Content-Type: application/json" \
+  -d '{"progress": "Did some exercise"}'
+```
+
+Get growth data:
+
+```bash
+curl http://localhost:8000/api/v1/growth
+```

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,0 +1,1 @@
+from .api import router

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .memory import router as memory_router
+from .growth import router as growth_router
+from .otakkecil import router as otakkecil_router
+
+router = APIRouter()
+router.include_router(memory_router, prefix="/memory", tags=["memory"])
+router.include_router(growth_router, prefix="/growth", tags=["growth"])
+router.include_router(otakkecil_router, prefix="/otakkecil", tags=["otakkecil"])

--- a/backend/app/api/v1/growth.py
+++ b/backend/app/api/v1/growth.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from app.models.growth import growth_db, Growth
+
+class GrowthCreate(BaseModel):
+    progress: str
+
+router = APIRouter()
+
+@router.get("/", response_model=list[Growth])
+async def list_growth():
+    return growth_db.all()
+
+@router.post("/", response_model=Growth)
+async def create_growth(item: GrowthCreate):
+    return growth_db.create(item.progress)

--- a/backend/app/api/v1/memory.py
+++ b/backend/app/api/v1/memory.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from app.models.memory import memory_db, Memory
+
+class MemoryCreate(BaseModel):
+    content: str
+
+router = APIRouter()
+
+@router.get("/", response_model=list[Memory])
+async def list_memories():
+    return memory_db.all()
+
+@router.post("/", response_model=Memory)
+async def create_memory(mem: MemoryCreate):
+    return memory_db.create(mem.content)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from app.api.v1.api import router as api_v1_router
+
+app = FastAPI(title="Dr Tan API")
+
+app.include_router(api_v1_router, prefix="/api/v1")
+
+@app.get("/")
+async def read_root():
+    return {"message": "ok"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,2 @@
+from .memory import Memory, memory_db
+from .growth import Growth, growth_db

--- a/backend/app/models/growth.py
+++ b/backend/app/models/growth.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import List
+from pydantic import BaseModel
+
+class Growth(BaseModel):
+    id: int
+    progress: str
+    created_at: datetime
+
+class GrowthDB:
+    def __init__(self):
+        self._data: List[Growth] = []
+        self._id = 1
+
+    def all(self) -> List[Growth]:
+        return self._data
+
+    def create(self, progress: str) -> Growth:
+        growth = Growth(id=self._id, progress=progress, created_at=datetime.utcnow())
+        self._id += 1
+        self._data.append(growth)
+        return growth
+
+growth_db = GrowthDB()

--- a/backend/app/models/memory.py
+++ b/backend/app/models/memory.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import List
+from pydantic import BaseModel
+
+class Memory(BaseModel):
+    id: int
+    content: str
+    timestamp: datetime
+
+class MemoryDB:
+    def __init__(self):
+        self._data: List[Memory] = []
+        self._id = 1
+
+    def all(self) -> List[Memory]:
+        return self._data
+
+    def create(self, content: str) -> Memory:
+        memory = Memory(id=self._id, content=content, timestamp=datetime.utcnow())
+        self._id += 1
+        self._data.append(memory)
+        return memory
+
+memory_db = MemoryDB()


### PR DESCRIPTION
## Summary
- add a simple FastAPI app in `backend/app/main.py`
- expose `/memory` and `/growth` endpoints
- implement in-memory models
- document example API usage in backend README

## Testing
- `pytest -q`
- `python -m uvicorn app.main:app --port 8001 --log-level warning` *(fails before installing deps)*
- `pip install fastapi uvicorn`
- `pip install httpx`
- `python -m uvicorn app.main:app --port 8001 --log-level warning` *(manual curl check)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8a328fc832485295c45254cda83