### PR TITLE
Add Music mini-player

### DIFF
--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -4,6 +4,7 @@ import '../otak_kecil/otak_kecil_page.dart';
 import 'beranda_provider.dart';
 import 'beranda_form.dart';
 import '../../core/common/pastel_empty_state.dart';
+import 'music_widget.dart';
 
 class BerandaWidget extends StatelessWidget {
   const BerandaWidget({super.key});
@@ -14,6 +15,8 @@ class BerandaWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        const MusicWidget(),
+        const SizedBox(height: 12),
         BerandaForm(onSubmit: provider.addNote),
         const SizedBox(height: 12),
         const Text("Catatan Beranda:", style: TextStyle(fontWeight: FontWeight.bold)),

--- a/lib/features/beranda/music_repository.dart
+++ b/lib/features/beranda/music_repository.dart
@@ -1,0 +1,24 @@
+class MusicTrack {
+  final String title;
+  final String url;
+  final String artworkUrl;
+
+  MusicTrack(this.title, this.url, this.artworkUrl);
+}
+
+class MusicRepository {
+  final List<MusicTrack> _playlist = [
+    MusicTrack(
+      'Sample 1',
+      'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+      'https://via.placeholder.com/150',
+    ),
+    MusicTrack(
+      'Sample 2',
+      'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
+      'https://via.placeholder.com/150',
+    ),
+  ];
+
+  List<MusicTrack> fetchPlaylist() => List.from(_playlist);
+}

--- a/lib/features/beranda/music_widget.dart
+++ b/lib/features/beranda/music_widget.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+
+import 'music_repository.dart';
+
+class MusicWidget extends StatefulWidget {
+  const MusicWidget({super.key});
+
+  @override
+  State<MusicWidget> createState() => _MusicWidgetState();
+}
+
+class _MusicWidgetState extends State<MusicWidget> {
+  late final AudioPlayer _player;
+  late final List<MusicTrack> _playlist;
+  int _current = 0;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _player = AudioPlayer();
+    _playlist = MusicRepository().fetchPlaylist();
+    _loadCurrent();
+  }
+
+  Future<void> _loadCurrent() async {
+    final track = _playlist[_current];
+    try {
+      await _player.setUrl(track.url);
+    } catch (_) {}
+    setState(() {
+      _loading = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    if (_player.playing) {
+      _player.pause();
+    } else {
+      _player.play();
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final track = _playlist[_current];
+    return Card(
+      child: ListTile(
+        leading: Image.network(
+          track.artworkUrl,
+          width: 50,
+          height: 50,
+          fit: BoxFit.cover,
+        ),
+        title: Text(track.title),
+        trailing: IconButton(
+          icon: Icon(_player.playing ? Icons.pause : Icons.play_arrow),
+          onPressed: _loading ? null : _toggle,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,9 @@
 name: dr_tan
-description: "Soul and Asistant"
-
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
+description: Soul and Asistant
+publish_to: none
 version: 1.0.0+1
-
 environment:
   sdk: ^3.8.1
-
 dependencies:
   flutter:
     sdk: flutter
@@ -15,7 +11,7 @@ dependencies:
   hive_flutter: ^1.1.0
   cupertino_icons: ^1.0.8
   provider: ^6.1.5
-
+  just_audio: ^0.9.36
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- declare `just_audio` in pubspec
- add a simple music repository and widget
- show the MusicWidget on Beranda

## Testing
- `pip install pyyaml` *(passed)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ec8e8fa083249cdc224a2f1bfe0b