### PR TITLE
Add carousel with article quotes

### DIFF
--- a/lib/features/beranda/article_quote_carousel.dart
+++ b/lib/features/beranda/article_quote_carousel.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+
+class ArticleQuoteCarousel extends StatelessWidget {
+  const ArticleQuoteCarousel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      'Tetaplah semangat untuk belajar dan berkembang setiap hari.',
+      'Kesehatan mental sama pentingnya dengan kesehatan fisik.',
+      'Luangkan waktu sejenak untuk merenung dan bersyukur.'
+    ];
+
+    return CarouselSlider.builder(
+      itemCount: items.length,
+      options: CarouselOptions(
+        height: 140,
+        autoPlay: true,
+        enlargeCenterPage: true,
+        viewportFraction: 0.85,
+      ),
+      itemBuilder: (context, index, realIdx) {
+        final text = items[index];
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 8),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Text(
+                    text,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.bottomRight,
+                  child: TextButton(
+                    onPressed: () {},
+                    child: const Text('Lihat Selengkapnya'),
+                  ),
+                )
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -5,6 +5,7 @@ import 'beranda_provider.dart';
 import 'beranda_form.dart';
 import '../../core/common/pastel_empty_state.dart';
 import 'music_widget.dart';
+import 'article_quote_carousel.dart';
 
 class BerandaWidget extends StatelessWidget {
   const BerandaWidget({super.key});
@@ -15,6 +16,8 @@ class BerandaWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        const ArticleQuoteCarousel(),
+        const SizedBox(height: 12),
         const MusicWidget(),
         const SizedBox(height: 12),
         BerandaForm(onSubmit: provider.addNote),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   provider: ^6.1.5
   just_audio: ^0.9.36
+  carousel_slider: ^5.1.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add `carousel_slider` dependency
- create `ArticleQuoteCarousel` widget for swipable quotes
- show carousel in `BerandaWidget`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ee01a9bc83249231bc687f417ddb