### PR TITLE
Add speech recognition quick journal

### DIFF
--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -6,6 +6,7 @@ import 'beranda_form.dart';
 import '../../core/common/pastel_empty_state.dart';
 import 'music_widget.dart';
 import 'article_quote_carousel.dart';
+import 'quick_journal_widget.dart';
 
 class BerandaWidget extends StatelessWidget {
   const BerandaWidget({super.key});
@@ -16,6 +17,8 @@ class BerandaWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        QuickJournalWidget(onSubmit: provider.addNote),
+        const SizedBox(height: 12),
         const ArticleQuoteCarousel(),
         const SizedBox(height: 12),
         const MusicWidget(),

--- a/lib/features/beranda/quick_journal_widget.dart
+++ b/lib/features/beranda/quick_journal_widget.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+
+class QuickJournalWidget extends StatefulWidget {
+  final void Function(String) onSubmit;
+  const QuickJournalWidget({super.key, required this.onSubmit});
+
+  @override
+  State<QuickJournalWidget> createState() => _QuickJournalWidgetState();
+}
+
+class _QuickJournalWidgetState extends State<QuickJournalWidget> {
+  final TextEditingController _controller = TextEditingController();
+  final stt.SpeechToText _speech = stt.SpeechToText();
+  bool _listening = false;
+
+  Future<void> _toggleListening() async {
+    if (_listening) {
+      await _speech.stop();
+      setState(() => _listening = false);
+    } else {
+      final available = await _speech.initialize();
+      if (available) {
+        setState(() => _listening = true);
+        _speech.listen(onResult: (result) {
+          setState(() {
+            _controller.text = result.recognizedWords;
+            _controller.selection = TextSelection.fromPosition(
+              TextPosition(offset: _controller.text.length),
+            );
+          });
+        });
+      }
+    }
+  }
+
+  void _submit() {
+    if (_controller.text.trim().isNotEmpty) {
+      widget.onSubmit(_controller.text.trim());
+      _controller.clear();
+    }
+  }
+
+  @override
+  void dispose() {
+    _speech.stop();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: _controller,
+            decoration: const InputDecoration(
+              labelText: 'Catatan cepat...',
+              border: OutlineInputBorder(),
+            ),
+            onSubmitted: (_) => _submit(),
+          ),
+        ),
+        IconButton(
+          icon: Icon(_listening ? Icons.mic_off : Icons.mic),
+          onPressed: _toggleListening,
+        ),
+        ElevatedButton(
+          onPressed: _submit,
+          child: const Icon(Icons.send),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   provider: ^6.1.5
   just_audio: ^0.9.36
   carousel_slider: ^5.1.1
+  speech_to_text: ^7.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add `speech_to_text` to Flutter dependencies
- create `QuickJournalWidget` for speech-based note input
- include quick journal at the top of `BerandaWidget`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863eed709a08324a8e5303ad666af41