### PR TITLE
Refine Beranda landing layout

### DIFF
--- a/lib/core/common/app_theme.dart
+++ b/lib/core/common/app_theme.dart
@@ -12,6 +12,10 @@ class AppTheme {
           brightness: Brightness.light,
         ),
         scaffoldBackgroundColor: _lightBackground,
+        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+          selectedItemColor: _pastelIndigo,
+          unselectedItemColor: Colors.grey,
+        ),
         visualDensity: const VisualDensity(horizontal: 2, vertical: 2),
         useMaterial3: true,
       );
@@ -22,6 +26,10 @@ class AppTheme {
           brightness: Brightness.dark,
         ),
         scaffoldBackgroundColor: _darkBackground,
+        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+          selectedItemColor: _pastelBlue,
+          unselectedItemColor: Colors.grey,
+        ),
         visualDensity: const VisualDensity(horizontal: 2, vertical: 2),
         useMaterial3: true,
       );

--- a/lib/features/beranda/beranda_page.dart
+++ b/lib/features/beranda/beranda_page.dart
@@ -1,19 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../../core/common/quick_add_dialog.dart';
 import '../../core/common/adaptive_greeting_banner.dart';
 import 'beranda_widget.dart';
-import 'beranda_provider.dart';
 
 class BerandaPage extends StatelessWidget {
   const BerandaPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => BerandaProvider(),
-      child: const _BerandaView(),
-    );
+    return const _BerandaView();
   }
 }
 
@@ -23,23 +17,19 @@ class _BerandaView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Beranda')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: const [
-            AdaptiveGreetingBanner(pageName: 'Beranda'),
-            Expanded(child: BerandaWidget()),
-          ],
+      appBar: AppBar(
+        title: const SizedBox.shrink(),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(120),
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: AdaptiveGreetingBanner(pageName: 'Beranda'),
+          ),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => showQuickAddDialog(
-          context,
-          context.read<BerandaProvider>().addNote,
-          hint: 'Tambah catatan...',
-        ),
-        child: const Icon(Icons.add),
+      body: const Padding(
+        padding: EdgeInsets.all(16),
+        child: BerandaWidget(),
       ),
     );
   }

--- a/lib/features/beranda/beranda_widget.dart
+++ b/lib/features/beranda/beranda_widget.dart
@@ -1,28 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import '../otak_kecil/otak_kecil_page.dart';
-import 'beranda_provider.dart';
-import 'beranda_form.dart';
-import '../../core/common/pastel_empty_state.dart';
 import 'music_widget.dart';
 import 'article_quote_carousel.dart';
-import 'quick_journal_widget.dart';
 
 class BerandaWidget extends StatelessWidget {
   const BerandaWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final provider = Provider.of<BerandaProvider>(context);
     return ListView(
       children: [
-        Card(
-          margin: const EdgeInsets.symmetric(vertical: 8),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: QuickJournalWidget(onSubmit: provider.addNote),
-          ),
-        ),
         Card(
           margin: const EdgeInsets.symmetric(vertical: 8),
           child: const ArticleQuoteCarousel(),
@@ -30,57 +17,6 @@ class BerandaWidget extends StatelessWidget {
         Card(
           margin: const EdgeInsets.symmetric(vertical: 8),
           child: const MusicWidget(),
-        ),
-        Card(
-          margin: const EdgeInsets.symmetric(vertical: 8),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                BerandaForm(onSubmit: provider.addNote),
-                const SizedBox(height: 12),
-                const Text(
-                  "Catatan Beranda:",
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 8),
-                AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 300),
-                  child: provider.notes.isEmpty
-                      ? const PastelEmptyState(
-                          message: "Belum ada catatan.",
-                          icon: Icons.note_add,
-                        )
-                      : ListView.builder(
-                          key: ValueKey(provider.notes.length),
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: provider.notes.length,
-                          itemBuilder: (ctx, i) => Dismissible(
-                            key: ValueKey(provider.notes[i]),
-                            direction: DismissDirection.endToStart,
-                            onDismissed: (_) => provider.removeNoteAt(i),
-                            background: Container(
-                              color: Colors.red,
-                              alignment: Alignment.centerRight,
-                              padding: const EdgeInsets.symmetric(horizontal: 16),
-                              child: const Icon(Icons.delete, color: Colors.white),
-                            ),
-                            child: Card(
-                              margin:
-                                  const EdgeInsets.symmetric(vertical: 4),
-                              child: ListTile(
-                                leading: const Icon(Icons.note),
-                                title: Text(provider.notes[i]),
-                              ),
-                            ),
-                          ),
-                        ),
-                ),
-              ],
-            ),
-          ),
         ),
         Card(
           margin: const EdgeInsets.symmetric(vertical: 8),


### PR DESCRIPTION
## Summary
- simplify Beranda widgets
- display greeting banner in the app bar
- style bottom navigation bar icons so they stay visible

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f5ca157c8324bfb0e9103ba1afed